### PR TITLE
Add multi-arch (arm64) support to release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,7 @@ jobs:
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ github.event.repository.full_name }}:latest
             ${{ github.event.repository.full_name }}:v${{ needs.release.outputs.release-version-major }}


### PR DESCRIPTION
I was hoping to add arm64 support to this action so both container architecture types are saved in the docker registry. It looks like the builx plugin is already set up in this action, so enabling the arm64 platform (as well as the existing amd64) should be all that is necessary. I am trying to run the [auto-merge-dependabot action](https://github.com/ahmadnassri/action-dependabot-auto-merge) on a raspberry pi k3s cluster (self-hosted runner), and the installation fails because of the lack of arm64 support. Unfortunately, the action succeeds despite the installation failure.

```
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
GITHUB_EVENT_PATH /github/workflow/event.json does not exist
GITHUB_EVENT_PATH /github/workflow/event.json does not exist
Warning: expected PR by "dependabot[bot]", found "no-sender" instead
```

I have successfully used these parameters in a self-hosted action you can see here:
https://github.com/mathew-fleisch/bashbot/blob/main/.github/workflows/build-container.yaml#L46

Please let me know if there is anything else I can do for this PR. Thanks!