### PR TITLE
fix(docker): ensure v2 of the node16 docker image is used from ghcr.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ branding:
 
 runs:
   using: docker
-  image: docker://ghcr.io/ahmadnassri/action-semantic-release:v1
+  image: docker://ghcr.io/ahmadnassri/action-semantic-release:v2
 
 inputs:
   config:


### PR DESCRIPTION
This updates the action to use the latest docker container built